### PR TITLE
Skip over malfunctioning CSS sheets

### DIFF
--- a/aug-attr-spliced.js
+++ b/aug-attr-spliced.js
@@ -17,7 +17,12 @@ const recursiveRuleCrawl = cssRules => {
   }
 }
 Array.from(document.styleSheets).forEach(
-  stylesheet => recursiveRuleCrawl(stylesheet.cssRules)
+  (stylesheet) => {
+    try {
+      recursiveRuleCrawl(stylesheet.cssRules)
+    } catch (e) {
+      console.log('Stylesheet unreadable: ', e, stylesheet)
+    }
 )
 
 const checkSetAttr = (el, attr, val) => {


### PR DESCRIPTION
Aggressive CORS enforcement on Firefox can cause issues on refresh of a page managed by this script. Allowing it to skip non-working CSS sheets via a try/catch will keep most pages working while ignoring problem sheets. 

I'm not sure what Firefox is doing, but it creates an inline sheet in the styleSheets list on refresh that would otherwise cause this script to fail. 